### PR TITLE
Fix syntax error in dashboard script

### DIFF
--- a/import streamlit as st.py
+++ b/import streamlit as st.py
@@ -289,6 +289,6 @@ else:
             plt.xticks(rotation=30, ha='right')
             fig_trend.tight_layout()
             st.pyplot(fig_trend)
- 
-working link with downloaded excel file
+
+# working link with downloaded excel file
  


### PR DESCRIPTION
## Summary
- comment out stray text to fix syntax error in `import streamlit as st.py`

## Testing
- `python -m py_compile "import streamlit as st.py"`

------
https://chatgpt.com/codex/tasks/task_e_685215e362cc8331a88cd0bee4844aa6